### PR TITLE
allow for bidi iterator rather than random access iterator as underlying type for utf8_iterator

### DIFF
--- a/include/u5e/utf8_iterator.hpp
+++ b/include/u5e/utf8_iterator.hpp
@@ -34,7 +34,7 @@ namespace u5e {
 
     inline void forward_one_codepoint() {
       difference_type size = utf8_utils::codepoint_size(*raw_iterator_);
-      raw_iterator_ += size;
+      std::advance(raw_iterator_, size);
     }
     
     inline bool rewind_to_start_of_codepoint(const char current_octet) {


### PR DESCRIPTION
+= is only guaranteed to be available on random access iterators; std::advance can fall back seamlessly
